### PR TITLE
cloud run 実装（dev）

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,61 @@
+# ======================================
+# Multi-stage Dockerfile for Go API
+# ======================================
+# Stage 1: Build stage
+FROM golang:1.23-alpine AS builder
+
+# Install git (required for go mod download)
+RUN apk add --no-cache git
+
+# Set working directory
+WORKDIR /app
+
+# Copy go.mod and go.sum first for better caching
+COPY go.mod go.sum ./
+
+# Download dependencies
+RUN go mod download
+
+# Copy source code
+COPY . .
+
+# Build the application
+# CGO_ENABLED=0 for static binary
+# GOOS=linux for linux container
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main .
+
+# ======================================
+# Stage 2: Production stage
+FROM alpine:latest
+
+# Install ca-certificates for HTTPS calls
+RUN apk --no-cache add ca-certificates
+
+# Create app directory
+WORKDIR /root/
+
+# Copy the binary from builder stage
+COPY --from=builder /app/main .
+
+# Copy migrations directory if exists
+COPY --from=builder /app/migrations ./migrations
+
+# Create non-root user for security
+RUN addgroup -g 1001 -S appgroup && \
+    adduser -S appuser -u 1001 -G appgroup
+
+# Change ownership to appuser
+RUN chown -R appuser:appgroup /root/
+
+# Switch to non-root user
+USER appuser
+
+# Expose port (Cloud Run will set PORT env var)
+EXPOSE 8080
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD wget --no-verbose --tries=1 --spider http://localhost:$PORT/health || exit 1
+
+# Run the application
+CMD ["./main"]

--- a/apps/api/db/db.go
+++ b/apps/api/db/db.go
@@ -5,9 +5,6 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/golang-migrate/migrate/v4"
-	"github.com/golang-migrate/migrate/v4/database/postgres"
-	_ "github.com/golang-migrate/migrate/v4/source/file"
 	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq"
 )
@@ -29,34 +26,14 @@ func InitDB(cfg *config.Config) error {
 
 	log.Println("Successfully connected to database")
 
-	// Run migrations
-	if err = runMigrations(cfg); err != nil {
-		return fmt.Errorf("failed to run migrations: %w", err)
-	}
+	// NOTE: Migrations are now handled by CI/CD pipeline (GitHub Actions)
+	// Manual migration command: migrate -path ./migrations -database $DATABASE_URL up
 
 	return nil
 }
 
-func runMigrations(cfg *config.Config) error {
-	driver, err := postgres.WithInstance(DB.DB, &postgres.Config{})
-	if err != nil {
-		return fmt.Errorf("could not create migration driver: %w", err)
-	}
-
-	m, err := migrate.NewWithDatabaseInstance(
-		"file://migrations",
-		"postgres", driver)
-	if err != nil {
-		return fmt.Errorf("could not create migrate instance: %w", err)
-	}
-
-	if err := m.Up(); err != nil && err != migrate.ErrNoChange {
-		return fmt.Errorf("could not run migrations: %w", err)
-	}
-
-	log.Println("Migrations completed successfully")
-	return nil
-}
+// runMigrations function removed - migrations now handled by CI/CD pipeline
+// For manual migration: migrate -path ./migrations -database $DATABASE_URL up
 
 func CloseDB() {
 	if DB != nil {

--- a/apps/api/main.go
+++ b/apps/api/main.go
@@ -8,6 +8,7 @@ import (
 	"api/usecase"
 	"log"
 	"net/http"
+	"os"
 
 	"github.com/gin-gonic/gin"
 )
@@ -116,10 +117,13 @@ func main() {
 		}
 	}
 
-	// サーバー起動
-	port := ":8080"
+	// サーバー起動 - Cloud Run対応でPORT環境変数を使用
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080" // ローカル開発時のデフォルト
+	}
 	log.Printf("Starting server on port %s", port)
-	if err := r.Run(port); err != nil {
+	if err := r.Run(":" + port); err != nil {
 		log.Fatal("Failed to start server: ", err)
 	}
 }

--- a/apps/terraform/gcp/environments/dev/api/cloudrun.tf
+++ b/apps/terraform/gcp/environments/dev/api/cloudrun.tf
@@ -1,0 +1,164 @@
+# ======================================
+# Cloud Run Service - VPC統合・セキュア構成
+# ======================================
+# GoアプリケーションAPIサーバーをCloud Runで実行
+# プライベートVPCに統合し、Cloud SQLと安全に通信
+
+# Cloud Run Service
+resource "google_cloud_run_v2_service" "api_service" {
+  name     = "api-service"
+  location = var.region
+
+  template {
+    # Service account for Cloud Run
+    service_account = google_service_account.api_cloud_run_sa.email
+
+    # VPC統合設定
+    vpc_access {
+      connector = data.terraform_remote_state.shared.outputs.vpc_connector_id
+      egress    = "PRIVATE_RANGES_ONLY"
+    }
+
+    # Container configuration
+    containers {
+      image = "gcr.io/${var.project_id}/api-service:latest"
+
+      ports {
+        container_port = 8080
+      }
+
+      # Resource limits
+      resources {
+        limits = {
+          cpu    = "1"
+          memory = "1Gi"
+        }
+        cpu_idle = true
+      }
+
+      # Environment variables
+      env {
+        name  = "GIN_MODE"
+        value = "release"
+      }
+
+      env {
+        name  = "DB_HOST"
+        value = google_sql_database_instance.api_db_instance.private_ip_address
+      }
+
+      env {
+        name  = "DB_PORT"
+        value = "5432"
+      }
+
+      env {
+        name  = "DB_NAME"
+        value = var.database_name
+      }
+
+      env {
+        name  = "DB_USER"
+        value = var.database_user
+      }
+
+      # Secret Manager からパスワード取得
+      env {
+        name = "DB_PASSWORD"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.db_password.secret_id
+            version = "latest"
+          }
+        }
+      }
+
+      env {
+        name  = "DB_SSLMODE"
+        value = "require"
+      }
+
+      env {
+        name  = "PROJECT_ID"
+        value = var.project_id
+      }
+    }
+
+    # Scaling configuration
+    scaling {
+      min_instance_count = 0
+      max_instance_count = 10
+    }
+  }
+
+  # Custom domain mapping (if specified)
+  dynamic "traffic" {
+    for_each = var.api_domain_name != "" ? [1] : []
+    content {
+      percent = 100
+      type    = "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST"
+    }
+  }
+
+  labels = var.labels
+
+  # 依存関係
+  depends_on = [
+    google_sql_database_instance.api_db_instance,
+    google_secret_manager_secret_version.db_password
+  ]
+}
+
+# ======================================
+# Service Account for Cloud Run
+# ======================================
+
+# Cloud Run用のサービスアカウント
+resource "google_service_account" "api_cloud_run_sa" {
+  account_id   = "api-cloud-run-sa"
+  display_name = "API Cloud Run Service Account"
+  description  = "Service account used by Cloud Run API service"
+}
+
+# Secret Manager読み取り権限
+resource "google_project_iam_member" "api_cloud_run_secret_accessor" {
+  project = var.project_id
+  role    = "roles/secretmanager.secretAccessor"
+  member  = "serviceAccount:${google_service_account.api_cloud_run_sa.email}"
+}
+
+# Cloud SQL接続権限
+resource "google_project_iam_member" "api_cloud_run_sql_client" {
+  project = var.project_id
+  role    = "roles/cloudsql.client"
+  member  = "serviceAccount:${google_service_account.api_cloud_run_sa.email}"
+}
+
+# ======================================
+# IAM Policies
+# ======================================
+
+# 開発環境：パブリックアクセス許可（本番環境では制限すること）
+resource "google_cloud_run_v2_service_iam_member" "api_service_public_access" {
+  location = google_cloud_run_v2_service.api_service.location
+  name     = google_cloud_run_v2_service.api_service.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}
+
+# ======================================
+# Custom Domain Mapping (Optional)
+# ======================================
+
+# Custom domain mapping (if domain name is provided)
+# resource "google_cloud_run_domain_mapping" "api_domain" {
+#   location = var.region
+#   name     = var.api_domain_name
+#   metadata {
+#     namespace = var.project_id
+#   }
+
+#   spec {
+#     route_name = google_cloud_run_v2_service.api_service.name
+#   }
+# }

--- a/apps/terraform/gcp/environments/dev/api/main.tf
+++ b/apps/terraform/gcp/environments/dev/api/main.tf
@@ -50,3 +50,106 @@ resource "google_certificate_manager_certificate_map_entry" "api_cert_map_entry"
   certificates = [google_certificate_manager_certificate.api_cert.id]
   hostname     = "dev.api.my-learn-iac-sample.site"
 }
+
+# ======================================
+# HTTPS Load Balancer Configuration for Custom Domain
+# ======================================
+
+# Backend Service for Cloud Run
+# Cloud RunサービスをHTTPS Load Balancerのバックエンドとして設定
+# NEG (Network Endpoint Group) を使用してCloud Runサービスに接続
+resource "google_compute_backend_service" "api_backend_service" {
+  name        = "api-backend-service"
+  description = "Backend service for API Cloud Run service"
+
+  # Cloud Run用のバックエンド設定
+  backend {
+    group = google_compute_region_network_endpoint_group.api_neg.id
+  }
+
+  # Serverless NEG (Cloud Run) にはヘルスチェック不要
+
+  # プロトコル設定
+  protocol    = "HTTP"
+  port_name   = "http"
+  timeout_sec = 30
+
+  # ログ設定
+  log_config {
+    enable      = true
+    sample_rate = 1.0
+  }
+}
+
+# Network Endpoint Group (NEG) for Cloud Run
+# Cloud RunサービスをLoad Balancerに接続するためのNEG
+resource "google_compute_region_network_endpoint_group" "api_neg" {
+  name                  = "api-neg"
+  network_endpoint_type = "SERVERLESS"
+  region                = var.region
+  description           = "NEG for API Cloud Run service"
+
+  cloud_run {
+    service = google_cloud_run_v2_service.api_service.name
+  }
+}
+
+# Cloud Runはサーバーレスなので、ヘルスチェックは不要（自動的に管理される）
+
+# URL Map for API Traffic Routing
+# HTTPSリクエストをCloud RunのBackend Serviceにルーティング
+resource "google_compute_url_map" "api_url_map" {
+  name            = "api-url-map"
+  default_service = google_compute_backend_service.api_backend_service.id
+  description     = "URL map for API HTTPS load balancer"
+}
+
+# HTTP to HTTPS redirect URL Map for API
+# HTTPアクセスを自動的にHTTPSにリダイレクト
+resource "google_compute_url_map" "api_https_redirect" {
+  name        = "api-https-redirect"
+  description = "URL map to redirect HTTP to HTTPS for API"
+
+  default_url_redirect {
+    redirect_response_code = "MOVED_PERMANENTLY_DEFAULT"
+    strip_query            = false
+    https_redirect         = true
+  }
+}
+
+# HTTPS Target Proxy for API
+# HTTPS接続を処理し、共通Certificate Mapを使用してSSL証明書を適用
+resource "google_compute_target_https_proxy" "api_https_proxy" {
+  name    = "api-https-proxy"
+  url_map = google_compute_url_map.api_url_map.id
+
+  # 共通Certificate Mapを参照
+  certificate_map = "//certificatemanager.googleapis.com/${data.terraform_remote_state.shared.outputs.shared_certificate_map.id}"
+}
+
+# HTTP Target Proxy for HTTPS redirect (API)
+# HTTPアクセスをHTTPSにリダイレクト
+resource "google_compute_target_http_proxy" "api_http_proxy" {
+  name    = "api-http-proxy"
+  url_map = google_compute_url_map.api_https_redirect.id
+}
+
+# HTTPS Forwarding Rule for API
+# 静的IPアドレスでHTTPSリクエストを受け付けてTarget Proxyに転送
+resource "google_compute_global_forwarding_rule" "api_https_forwarding_rule" {
+  name        = "api-https-rule"
+  target      = google_compute_target_https_proxy.api_https_proxy.id
+  port_range  = "443"
+  ip_protocol = "TCP"
+  ip_address  = data.terraform_remote_state.shared.outputs.api_static_ip_address
+}
+
+# HTTP Forwarding Rule for API (redirect to HTTPS)
+# HTTPリクエストを受け付けてHTTPSにリダイレクト
+resource "google_compute_global_forwarding_rule" "api_http_forwarding_rule" {
+  name        = "api-http-rule"
+  target      = google_compute_target_http_proxy.api_http_proxy.id
+  port_range  = "80"
+  ip_protocol = "TCP"
+  ip_address  = data.terraform_remote_state.shared.outputs.api_static_ip_address
+}

--- a/apps/terraform/gcp/environments/dev/api/main.tf
+++ b/apps/terraform/gcp/environments/dev/api/main.tf
@@ -43,10 +43,10 @@ resource "google_certificate_manager_certificate" "api_cert" {
   depends_on = [data.terraform_remote_state.shared]
 }
 
-# 既存のCertificate MapにAPI用エントリーを追加
+# 共通Certificate MapにAPI用エントリーを追加
 resource "google_certificate_manager_certificate_map_entry" "api_cert_map_entry" {
   name         = "api-cert-map-entry"
-  map          = "dashboard-cert-map" # 既存のmapを使用
+  map          = data.terraform_remote_state.shared.outputs.shared_certificate_map.name
   certificates = [google_certificate_manager_certificate.api_cert.id]
   hostname     = "dev.api.my-learn-iac-sample.site"
 }

--- a/apps/terraform/gcp/environments/dev/api/main.tf
+++ b/apps/terraform/gcp/environments/dev/api/main.tf
@@ -25,3 +25,28 @@ data "terraform_remote_state" "shared" {
     prefix = "dev/shared"
   }
 }
+
+# ======================================
+# API Certificate Manager Resources
+# ======================================
+resource "google_certificate_manager_certificate" "api_cert" {
+  name = "api-cert"
+
+
+  location = "global"
+
+  managed {
+    domains = ["dev.api.my-learn-iac-sample.site"]
+  }
+
+  # Certificate Manager API有効化後に作成
+  depends_on = [data.terraform_remote_state.shared]
+}
+
+# 既存のCertificate MapにAPI用エントリーを追加
+resource "google_certificate_manager_certificate_map_entry" "api_cert_map_entry" {
+  name         = "api-cert-map-entry"
+  map          = "dashboard-cert-map" # 既存のmapを使用
+  certificates = [google_certificate_manager_certificate.api_cert.id]
+  hostname     = "dev.api.my-learn-iac-sample.site"
+}

--- a/apps/terraform/gcp/environments/dev/api/outputs.tf
+++ b/apps/terraform/gcp/environments/dev/api/outputs.tf
@@ -64,3 +64,29 @@ output "certificate_status" {
     domain         = var.api_domain_name
   }
 }
+
+# Load Balancer Information
+output "load_balancer_ip" {
+  description = "Static IP address for the API load balancer"
+  value       = data.terraform_remote_state.shared.outputs.api_static_ip_address
+}
+
+output "https_load_balancer_url" {
+  description = "HTTPS URL for the API with custom domain"
+  value       = "https://${var.api_domain_name}"
+}
+
+output "load_balancer_url" {
+  description = "HTTP URL for the API load balancer (redirects to HTTPS)"
+  value       = "http://${data.terraform_remote_state.shared.outputs.api_static_ip_address}"
+}
+
+output "backend_service_name" {
+  description = "Backend service name for the API load balancer"
+  value       = google_compute_backend_service.api_backend_service.name
+}
+
+output "neg_name" {
+  description = "Network Endpoint Group name for Cloud Run service"
+  value       = google_compute_region_network_endpoint_group.api_neg.name
+}

--- a/apps/terraform/gcp/environments/dev/api/outputs.tf
+++ b/apps/terraform/gcp/environments/dev/api/outputs.tf
@@ -28,13 +28,29 @@ output "database_user" {
   sensitive   = true
 }
 
+# Cloud Run Service Information
+output "api_service_name" {
+  description = "Cloud Run API service name"
+  value       = google_cloud_run_v2_service.api_service.name
+}
+
+output "api_service_url" {
+  description = "Cloud Run API service URL"
+  value       = google_cloud_run_v2_service.api_service.uri
+}
+
+output "api_service_account_email" {
+  description = "Cloud Run service account email"
+  value       = google_service_account.api_cloud_run_sa.email
+}
+
 # DNS Records Required (for manual DNS setup)
 output "api_dns_records_required" {
   description = "DNS records that need to be configured manually"
-  value = {
+  value = var.api_domain_name != "" ? {
     domain = var.api_domain_name
-    type   = "A"
-    value  = data.terraform_remote_state.shared.outputs.api_static_ip_address
+    type   = "CNAME"
+    value  = "ghs.googlehosted.com."
     ttl    = 300
-  }
+  } : null
 }

--- a/apps/terraform/gcp/environments/dev/api/outputs.tf
+++ b/apps/terraform/gcp/environments/dev/api/outputs.tf
@@ -47,10 +47,20 @@ output "api_service_account_email" {
 # DNS Records Required (for manual DNS setup)
 output "api_dns_records_required" {
   description = "DNS records that need to be configured manually"
-  value = var.api_domain_name != "" ? {
+  value = {
     domain = var.api_domain_name
     type   = "CNAME"
-    value  = "ghs.googlehosted.com."
-    ttl    = 300
-  } : null
+    value  = "ghs.googlehosted.com." # 要らなそう
+    ttl    = 300                     # 要らなそう
+  }
+}
+
+output "certificate_status" {
+  description = "SSL certificate status and information"
+  value = {
+    certificate_id = google_certificate_manager_certificate.api_cert.id
+    status_message = "Certificate configured - check GCP Console for detailed status"
+    console_url    = "https://console.cloud.google.com/security/ccm/list/certificates?project=${var.project_id}"
+    domain         = var.api_domain_name
+  }
 }

--- a/apps/terraform/gcp/environments/dev/dashboard/outputs.tf
+++ b/apps/terraform/gcp/environments/dev/dashboard/outputs.tf
@@ -70,11 +70,6 @@ output "certificate_status" {
   }
 }
 
-output "certificate_map_id" {
-  description = "Certificate Map ID"
-  value       = google_certificate_manager_certificate_map.website_cert_map.id
-}
-
 # ======================================
 # DNS Configuration Information
 # ======================================

--- a/apps/terraform/gcp/environments/dev/shared/apis.tf
+++ b/apps/terraform/gcp/environments/dev/shared/apis.tf
@@ -61,3 +61,23 @@ resource "google_project_service" "iap_api" {
   disable_dependent_services = true
   disable_on_destroy         = false
 }
+
+# Enable Serverless VPC Access API
+# Cloud RunサービスがVPCネットワーク内のリソースにアクセスするためのAPIを有効化
+# VPCアクセスコネクターの作成・管理に使用される
+resource "google_project_service" "vpcaccess_api" {
+  service = "vpcaccess.googleapis.com"
+
+  disable_dependent_services = true
+  disable_on_destroy         = false
+}
+
+# Enable Cloud Run Admin API
+# Cloud Runサービスの作成・管理・設定に必要なAPIを有効化
+# Cloud Runサービスのデプロイ、設定変更、管理に使用される
+resource "google_project_service" "run_api" {
+  service = "run.googleapis.com"
+
+  disable_dependent_services = true
+  disable_on_destroy         = false
+}

--- a/apps/terraform/gcp/environments/dev/shared/certificate_map.tf
+++ b/apps/terraform/gcp/environments/dev/shared/certificate_map.tf
@@ -1,0 +1,15 @@
+
+# ======================================
+# Shared Certificate Map
+# ======================================
+
+# 共通Certificate Map（全サービスの証明書を管理）
+resource "google_certificate_manager_certificate_map" "shared_cert_map" {
+  name        = "shared-cert-map"
+  description = "Shared certificate map for all services (dashboard, api, etc.)"
+
+  labels = {
+    purpose    = "shared-certificate-map"
+    managed_by = "terraform"
+  }
+}

--- a/apps/terraform/gcp/environments/dev/shared/iam.tf
+++ b/apps/terraform/gcp/environments/dev/shared/iam.tf
@@ -1,6 +1,13 @@
 # IAM設定ファイル - dev環境全体用（プロジェクトレベル）
 
 # ======================================
+# Data Sources
+# ======================================
+
+# 現在のプロジェクト情報を取得
+data "google_project" "current" {}
+
+# ======================================
 # Shared IAM Custom Roles
 # ======================================
 
@@ -45,6 +52,8 @@ resource "google_project_iam_binding" "dev_team_editor" {
 
   members = [
     "group:${var.dev_team_group}",
+    # Google APIs Service Agent - VPCコネクター作成に必要
+    "serviceAccount:${data.google_project.current.number}@cloudservices.gserviceaccount.com",
   ]
 }
 

--- a/apps/terraform/gcp/environments/dev/shared/main.tf
+++ b/apps/terraform/gcp/environments/dev/shared/main.tf
@@ -12,4 +12,3 @@ provider "google" {
   project = var.project_id
   region  = var.region
 }
-

--- a/apps/terraform/gcp/environments/dev/shared/network.tf
+++ b/apps/terraform/gcp/environments/dev/shared/network.tf
@@ -154,3 +154,29 @@ resource "google_compute_global_address" "api_ip" {
   address_type = "EXTERNAL"
   # IPアドレスは自動的に割り当てられます
 }
+
+# ======================================
+# Serverless VPC Access Connector
+# ======================================
+# Cloud RunサービスがVPCネットワーク内のリソース（Cloud SQL等）にアクセスするためのコネクター
+# Cloud Runはサーバーレスのため、デフォルトではVPCに接続されていない
+
+# VPC Access Connector for Cloud Run
+resource "google_vpc_access_connector" "main_connector" {
+  name          = "main-connector"
+  ip_cidr_range = "10.1.4.0/28"  # /28で16個のIPアドレスを使用
+  network       = google_compute_network.main_vpc.name
+  region        = var.region
+  
+  # コネクターの最小・最大インスタンス数
+  min_instances = 2
+  max_instances = 10
+  
+  # マシンタイプ（小規模構成）
+  machine_type = "e2-micro"
+  
+  # スループット設定（現在のリソースに合わせる）
+  max_throughput = 1000
+
+  depends_on = [google_compute_network.main_vpc]
+}

--- a/apps/terraform/gcp/environments/dev/shared/outputs.tf
+++ b/apps/terraform/gcp/environments/dev/shared/outputs.tf
@@ -132,4 +132,3 @@ output "vpc_connector_name" {
   description = "VPC Access Connector name"
   value       = google_vpc_access_connector.main_connector.name
 }
-

--- a/apps/terraform/gcp/environments/dev/shared/outputs.tf
+++ b/apps/terraform/gcp/environments/dev/shared/outputs.tf
@@ -119,3 +119,17 @@ output "api_static_ip_id" {
   value       = google_compute_global_address.api_ip.id
 }
 
+# ======================================
+# Serverless VPC Access Connector
+# ======================================
+
+output "vpc_connector_id" {
+  description = "VPC Access Connector ID for Cloud Run services"
+  value       = google_vpc_access_connector.main_connector.id
+}
+
+output "vpc_connector_name" {
+  description = "VPC Access Connector name"
+  value       = google_vpc_access_connector.main_connector.name
+}
+

--- a/apps/terraform/gcp/environments/dev/shared/outputs.tf
+++ b/apps/terraform/gcp/environments/dev/shared/outputs.tf
@@ -132,3 +132,12 @@ output "vpc_connector_name" {
   description = "VPC Access Connector name"
   value       = google_vpc_access_connector.main_connector.name
 }
+
+# Certificate Map
+output "shared_certificate_map" {
+  description = "Shared Certificate Map name"
+  value = {
+    name = google_certificate_manager_certificate_map.shared_cert_map.name
+    id   = google_certificate_manager_certificate_map.shared_cert_map.id
+  }
+}


### PR DESCRIPTION
## API 向け HTTPS Load Balancer - PR ドキュメント

### 概要

`https://dev.api.my-learn-iac-sample.site` を公開するために、Cloud Run(サーバーレス) をバックエンドとする GCLB(HTTPS) を構築。証明書は Certificate Manager の共通 `shared-cert-map` を利用し、HTTP から HTTPS へは 301 リダイレクト。Cloud Run とは Serverless NEG 経由で接続。

### 実装サマリ (Phase 3.8)

- **エンドポイント**: `https://dev.api.my-learn-iac-sample.site`
- **バックエンド**: Cloud Run `api-service` を Serverless NEG 経由で接続
- **証明書**: Certificate Manager 管理証明書 `api-cert` を共通 Certificate Map `shared-cert-map` にエントリ追加 (`api-cert-map-entry`)
- **リダイレクト**: HTTP(80) → HTTPS(443) を URL Map で 301 リダイレクト
- **静的IP**: グローバル静的IP (例: `34.107.246.141`)

---

## 実装詳細

### 構成要素 (主要リソース)

1. Backend Service: `google_compute_backend_service.api_backend_service`
   - Serverless NEG で Cloud Run に接続
   - ログ有効化、プロトコル HTTP、ポート名 `http`
2. NEG(Serverless): `google_compute_region_network_endpoint_group.api_neg`
   - Cloud Run サービス `api-service` を参照
3. URL Map(本系): `google_compute_url_map.api_url_map`
   - HTTPS リクエストを Backend Service にルーティング
4. URL Map(HTTPSリダイレクト): `google_compute_url_map.api_https_redirect`
   - HTTP を HTTPS に 301 リダイレクト
5. HTTPS Target Proxy: `google_compute_target_https_proxy.api_https_proxy`
   - `certificate_map` に `shared-cert-map` を指定して終端
6. HTTP Target Proxy: `google_compute_target_http_proxy.api_http_proxy`
   - リダイレクト用 URL Map を参照
7. Forwarding Rule(HTTPS/HTTP):
   - `google_compute_global_forwarding_rule.api_https_forwarding_rule` (443/TCP)
   - `google_compute_global_forwarding_rule.api_http_forwarding_rule` (80/TCP)

### 証明書・Certificate Map

- 証明書: `google_certificate_manager_certificate.api_cert` (Google 管理、ドメイン: `dev.api.my-learn-iac-sample.site`)
- 共有 Certificate Map: `shared-cert-map`
- Map Entry(API): `google_certificate_manager_certificate_map_entry.api_cert_map_entry` (hostname: `dev.api.my-learn-iac-sample.site`)

### Cloud Run・データベース接続

- Cloud Run サービス: `google_cloud_run_v2_service.api_service`
  - VPC Access Connector を利用し `PRIVATE_RANGES_ONLY` で egress 制御
  - Cloud SQL(PostgreSQL) とはプライベート IP で接続
  - 環境変数: `DB_HOST`(プライベートIP), `DB_PORT`=`5432`, `DB_NAME`, `DB_USER`, `DB_PASSWORD(Secret Manager)` 等
- Cloud SQL インスタンス: `google_sql_database_instance.api_db_instance`
  - パブリック IP 無効、プライベートサービス接続、バックアップ/メンテ/Insights 有効

---

## アーキテクチャ図

```mermaid
graph TB
    subgraph "Internet"
        User["ユーザー"]
    end

    subgraph "GCP Load Balancer (API)"
        StaticIP["静的 IP<br/>例: 34.107.246.141"]
        HTTPRule["HTTP Forwarding Rule<br/>Port 80"]
        HTTPSRule["HTTPS Forwarding Rule<br/>Port 443"]

        HTTPProxy["HTTP Target Proxy<br/>api-http-proxy"]
        HTTPSProxy["HTTPS Target Proxy<br/>api-https-proxy"]

        URLMapRedirect["URL Map<br/>api-https-redirect<br/>(HTTP→HTTPS)"]
        URLMapAPI["URL Map<br/>api-url-map<br/>(API Routing)"]

        BackendService["Backend Service<br/>api-backend-service"]
    end

    subgraph "Certificate Manager (Shared)"
        SharedCertMap["Shared Certificate Map<br/>shared-cert-map"]
        APICert["API Certificate<br/>api-cert"]
        DashboardCert["Dashboard Certificate<br/>dashboard-cert"]

        APICertEntry["API Cert Entry<br/>api-cert-map-entry"]
        DashboardCertEntry["Dashboard Cert Entry<br/>dashboard-cert-map-entry"]
    end

    subgraph "Cloud Run (API)"
        NEG["Network Endpoint Group<br/>api-neg<br/>(Serverless)"]
        CloudRunAPI["Cloud Run Service<br/>api-service"]
    end

    subgraph "Database"
        CloudSQL["Cloud SQL<br/>api-db-instance<br/>(Private)"]
    end

    %% User connections
    User -->|dev.api.my-learn-iac-sample.site| StaticIP
    User -->|HTTPS Request| HTTPSRule
    User -->|HTTP Request| HTTPRule

    %% Load Balancer flow
    HTTPRule --> HTTPProxy
    HTTPSRule --> HTTPSProxy

    HTTPProxy --> URLMapRedirect
    HTTPSProxy --> URLMapAPI

    URLMapRedirect -.->|301 Redirect| HTTPSProxy
    URLMapAPI --> BackendService

    BackendService --> NEG
    NEG --> CloudRunAPI

    %% Certificate Management
    HTTPSProxy -.->|Uses| SharedCertMap
    SharedCertMap --> APICertEntry
    APICertEntry --> APICert

    %% Database connection
    CloudRunAPI -.->|Private VPC| CloudSQL

    %% Styling
    classDef userClass fill:#e1f5fe,stroke:#0277bd,stroke-width:2px
    classDef lbClass fill:#f3e5f5,stroke:#7b1fa2,stroke-width:2px
    classDef certClass fill:#fff3e0,stroke:#f57c00,stroke-width:2px
    classDef appClass fill:#e8f5e8,stroke:#388e3c,stroke-width:2px
    classDef dbClass fill:#fce4ec,stroke:#c2185b,stroke-width:2px

    class User userClass
    class StaticIP,HTTPRule,HTTPSRule,HTTPProxy,HTTPSProxy,URLMapRedirect,URLMapAPI,BackendService lbClass
    class SharedCertMap,APICert,DashboardCert,APICertEntry,DashboardCertEntry certClass
    class NEG,CloudRunAPI appClass
    class CloudSQL dbClass
```

---

## テスト結果

### HTTPS 応答確認

```bash
curl -I https://dev.api.my-learn-iac-sample.site/
# 期待: HTTP/2 で 200/3xx/4xx 応答 (証明書は有効)
```

### HTTP→HTTPS リダイレクト確認

```bash
curl -I http://34.107.246.141 -H "Host: dev.api.my-learn-iac-sample.site"
# 期待: 301 Moved Permanently (Location: https://dev.api.my-learn-iac-sample.site/)
```

### 証明書状態

```bash
gcloud certificate-manager certificates describe api-cert --location=global
# 期待: State: ACTIVE, Authorization: AUTHORIZED
```

---

## 変更ファイル

- `apps/terraform/gcp/environments/dev/api/main.tf` (HTTPS LB, URL Map, Target Proxy, Forwarding Rule, NEG など)
- `apps/terraform/gcp/environments/dev/api/outputs.tf` (エンドポイント/証明書/NEG 名称等の出力)

---

## 次のステップ

- Phase 4: CI/CD (GitHub Actions, monorepo)。デプロイパイプラインから Cloud Run へコンテナを更新し、Terraform はインフラのドリフト検知/管理を継続。
- 監視/ログ: LB アクセスログ、Cloud Run 指標、Certificate Manager ステータスの可視化整備。

---

## 検証コマンド

```bash
# HTTPS 応答
curl https://dev.api.my-learn-iac-sample.site/

# DNS 解決
nslookup dev.api.my-learn-iac-sample.site

# 証明書ステータス
gcloud certificate-manager certificates describe api-cert --location=global
```

---

## 実装タイムライン (抜粋)

- DNS A レコード設定: `dev.api.my-learn-iac-sample.site` → API 用静的IP
- Certificate Manager 証明書 `api-cert` 作成 (DNS 伝播後に自動承認→ACTIVE)
- 共有 `shared-cert-map` に API エントリ追加
- HTTPS Load Balancer 構築 (静的IP + 証明書 + URL Map)
- Serverless NEG で Cloud Run と接続
- HTTP→HTTPS リダイレクト確認

---

## リソース作成サマリ

### 作成

1. `google_certificate_manager_certificate.api_cert`
2. `google_certificate_manager_certificate_map_entry.api_cert_map_entry`
3. `google_compute_region_network_endpoint_group.api_neg`
4. `google_compute_backend_service.api_backend_service`
5. `google_compute_url_map.api_url_map`
6. `google_compute_url_map.api_https_redirect`
7. `google_compute_target_https_proxy.api_https_proxy`
8. `google_compute_target_http_proxy.api_http_proxy`
9. `google_compute_global_forwarding_rule.api_https_forwarding_rule`
10. `google_compute_global_forwarding_rule.api_http_forwarding_rule`

### 削除/非採用

- ヘルスチェック (Serverless NEG/Cloud Run は不要)

---

## セキュリティ考慮

- TLS 終端: Certificate Manager による自動更新/管理 (Google Managed)
- HTTP→HTTPS 強制リダイレクト
- Cloud SQL はプライベート IP のみ、パブリック IP 無効
- Cloud Run は VPC コネクタ経由 (`PRIVATE_RANGES_ONLY`) で外部通信制御
- 秘密情報(DB パスワード)は Secret Manager から参照

---

## パフォーマンス/運用

- Backend Service ログを有効化し、可観測性を担保
- スケーリング: Cloud Run は最小 0、最大 10 でオートスケール
- 証明書の初回プロビジョニングは DNS 伝播後 10〜60分程度

---

## まとめ

Cloud Run をバックエンドとする HTTPS Load Balancer を構築し、独自ドメイン `dev.api.my-learn-iac-sample.site` での安全な公開を実現。証明書は共通 Certificate Map 経由で一元管理し、HTTP→HTTPS リダイレクトとプライベート接続によりセキュリティと運用性を両立。

